### PR TITLE
Refactor chaincode install and queryinstalled to use gRPC connection

### DIFF
--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -11,8 +11,8 @@ jobs:
   unit-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
-      - uses: actions/setup-go@main
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
         with:
           go-version: 1.18
       - run: make generate

--- a/.github/workflows/golang_nofunction.yml
+++ b/.github/workflows/golang_nofunction.yml
@@ -11,8 +11,8 @@ jobs:
   gofmt_test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
-      - uses: actions/setup-go@main
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
         with:
           go-version: 1.18
       - name: run gofmt test
@@ -20,8 +20,8 @@ jobs:
   escapes_detect:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
-      - uses: actions/setup-go@main
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
         with:
           go-version: 1.18
       - name: run escapes detect
@@ -29,8 +29,8 @@ jobs:
   vulnerability_detect:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
-      - uses: actions/setup-go@main
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
         with:
           go-version: 1.18
       - name: run vulnerability detect
@@ -38,8 +38,8 @@ jobs:
   golint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
-      - uses: actions/setup-go@main
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
         with:
           go-version: 1.18
       - run: make generate

--- a/.github/workflows/golange2e.yml
+++ b/.github/workflows/golange2e.yml
@@ -14,8 +14,8 @@ jobs:
   end-to-end:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
-      - uses: actions/setup-go@main
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
         with:
           go-version: 1.18
       - run: curl -vsS https://raw.githubusercontent.com/hyperledger/fabric/master/scripts/bootstrap.sh | bash

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -10,7 +10,7 @@ jobs:
         working-directory: node
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v3
       - name: check default node version
         run: node --version
       - run: npm i
@@ -27,7 +27,7 @@ jobs:
   #      working-directory: ts
   #  runs-on: ubuntu-latest
   #  steps:
-  #    - uses: actions/checkout@main
+  #    - uses: actions/checkout@v3
   #    - run: npm i
   #      working-directory: ts/formatter
   #    - run: npm test

--- a/go/Makefile
+++ b/go/Makefile
@@ -1,7 +1,7 @@
 .PHONY: unit-test
 unit-test:
 	@echo "Run unit test......"
-	go test -v -coverpkg=./pkg/... -coverprofile=coverage.out ./pkg/...
+	go test -coverpkg=./pkg/... -coverprofile=coverage.out ./pkg/...
 
 include gotools.mk
 

--- a/go/go.mod
+++ b/go/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/Knetic/govaluate v3.0.0+incompatible
 	github.com/Shopify/sarama v1.34.1
 	github.com/golang/mock v1.6.0
-	github.com/golang/protobuf v1.5.2
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/hashicorp/go-version v1.5.0
 	github.com/hyperledger/fabric v2.1.1+incompatible
@@ -28,6 +27,7 @@ require (
 	github.com/eapache/queue v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
@@ -55,7 +55,7 @@ require (
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.21.0 // indirect
-	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e // indirect
+	golang.org/x/crypto v0.1.0 // indirect
 	golang.org/x/net v0.2.0 // indirect
 	golang.org/x/sys v0.2.0 // indirect
 	golang.org/x/text v0.4.0 // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -331,8 +331,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201112155050-0c6587e931a9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e h1:T8NU3HyQ8ClP4SEE+KbFlg6n0NhuTsN4MyznaarGsZM=
-golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.1.0 h1:MDRAIl0xIo9Io2xV565hzXHw3zVseKrJKodhohM5CjU=
+golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/go/internal/protoutil/protoutil.go
+++ b/go/internal/protoutil/protoutil.go
@@ -10,24 +10,6 @@ import (
 	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
 )
 
-// CreateChaincodeProposalWithTxIDAndTransient creates a proposal from given
-// input. It returns the proposal and the transaction id associated with the
-// proposal
-func CreateChaincodeProposalWithTxIDAndTransient(typ common.HeaderType, channelID string, cis *peer.ChaincodeInvocationSpec, creator []byte, txid string, transientMap map[string][]byte) (*peer.Proposal, string, error) {
-	// generate a random nonce
-	nonce, err := getRandomNonce()
-	if err != nil {
-		return nil, "", err
-	}
-
-	// compute txid unless provided by tests
-	if txid == "" {
-		txid = ComputeTxID(nonce, creator)
-	}
-
-	return CreateChaincodeProposalWithTxIDNonceAndTransient(txid, typ, channelID, cis, nonce, creator, transientMap)
-}
-
 // CreateSignedTx assembles an Envelope message from proposal, endorsements,
 // and a signer. This function should be called by a client when it has
 // collected enough endorsements for a proposal to create a transaction and

--- a/go/pkg/chaincode/chaincode_suite_test.go
+++ b/go/pkg/chaincode/chaincode_suite_test.go
@@ -12,6 +12,8 @@ func TestChaincode(t *testing.T) {
 	RunSpecs(t, "Chaincode Suite")
 }
 
+const processProposalMethod = "/protos.Endorser/ProcessProposal"
+
 var tmpDir string
 
 var _ = BeforeSuite(func() {

--- a/go/pkg/chaincode/install.go
+++ b/go/pkg/chaincode/install.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
 	"github.com/hyperledger/fabric-protos-go-apiv2/peer/lifecycle"
+	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -17,7 +18,8 @@ const (
 	installTransactionName = "InstallChaincode"
 )
 
-func Install(ctx context.Context, endorser peer.EndorserClient, signer identity.SignerSerializer, packageReader io.Reader) error {
+// Install a chaincode package to specific peer.
+func Install(ctx context.Context, connection grpc.ClientConnInterface, signer identity.SignerSerializer, packageReader io.Reader) error {
 	packageBytes, err := io.ReadAll(packageReader)
 	if err != nil {
 		return fmt.Errorf("failed to read chaincode package: %w", err)
@@ -40,6 +42,8 @@ func Install(ctx context.Context, endorser peer.EndorserClient, signer identity.
 	if err != nil {
 		return err
 	}
+
+	endorser := peer.NewEndorserClient(connection)
 
 	proposalResponse, err := endorser.ProcessProposal(ctx, signedProposal)
 	if err != nil {

--- a/go/pkg/chaincode/install_test.go
+++ b/go/pkg/chaincode/install_test.go
@@ -3,25 +3,23 @@ package chaincode_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fabric-admin-sdk/internal/pkg/identity/mocks"
 	"fabric-admin-sdk/pkg/chaincode"
 	"io"
 	"strings"
 
-	"errors"
-
 	"github.com/golang/mock/gomock"
-	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
 	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
 	"github.com/hyperledger/fabric-protos-go-apiv2/peer/lifecycle"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc"
-	"google.golang.org/protobuf/runtime/protoiface"
+	"google.golang.org/protobuf/proto"
 )
 
-//go:generate mockgen -destination ./endorser_mock_test.go -package ${GOPACKAGE} github.com/hyperledger/fabric-protos-go-apiv2/peer EndorserClient
+//go:generate mockgen -destination ./clientconnection_mock_test.go -package ${GOPACKAGE} google.golang.org/grpc ClientConnInterface
 
 func NewProposalResponse(status common.Status, message string) *peer.ProposalResponse {
 	return &peer.ProposalResponse{
@@ -33,7 +31,7 @@ func NewProposalResponse(status common.Status, message string) *peer.ProposalRes
 }
 
 // AssertUnmarshal ensures that a protobuf is umarshaled without error
-func AssertUnmarshal(b []byte, m protoiface.MessageV1) {
+func AssertUnmarshal(b []byte, m proto.Message) {
 	err := proto.Unmarshal(b, m)
 	Expect(err).NotTo(HaveOccurred())
 }
@@ -81,6 +79,13 @@ func AssertUnmarshalInvocationSpec(signedProposal *peer.SignedProposal) *peer.Ch
 	return input
 }
 
+func CopyProto(from proto.Message, to proto.Message) {
+	protoBytes, err := proto.Marshal(from)
+	Expect(err).NotTo(HaveOccurred())
+	err = proto.Unmarshal(protoBytes, to)
+	Expect(err).NotTo(HaveOccurred())
+}
+
 var _ = Describe("Install", func() {
 	var mockSigner *mocks.SignerSerializer
 	var packageReader io.Reader
@@ -94,12 +99,14 @@ var _ = Describe("Install", func() {
 		controller, ctx := gomock.WithContext(specCtx, GinkgoT())
 		defer controller.Finish()
 
-		mockEndorser := NewMockEndorserClient(controller)
-		mockEndorser.EXPECT().
-			ProcessProposal(gomock.Eq(ctx), gomock.Any(), gomock.Any()).
-			Return(NewProposalResponse(common.Status_SUCCESS, ""), nil)
+		mockConnection := NewMockClientConnInterface(controller)
+		mockConnection.EXPECT().
+			Invoke(gomock.Eq(ctx), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
+			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
+				CopyProto(NewProposalResponse(common.Status_SUCCESS, ""), out)
+			})
 
-		err := chaincode.Install(ctx, mockEndorser, mockSigner, packageReader)
+		err := chaincode.Install(ctx, mockConnection, mockSigner, packageReader)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -109,12 +116,12 @@ var _ = Describe("Install", func() {
 		controller, ctx := gomock.WithContext(specCtx, GinkgoT())
 		defer controller.Finish()
 
-		mockEndorser := NewMockEndorserClient(controller)
-		mockEndorser.EXPECT().
-			ProcessProposal(gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(nil, expectedErr)
+		mockConnection := NewMockClientConnInterface(controller)
+		mockConnection.EXPECT().
+			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(expectedErr)
 
-		err := chaincode.Install(ctx, mockEndorser, mockSigner, packageReader)
+		err := chaincode.Install(ctx, mockConnection, mockSigner, packageReader)
 
 		Expect(err).To(MatchError(expectedErr))
 	})
@@ -126,12 +133,14 @@ var _ = Describe("Install", func() {
 		controller, ctx := gomock.WithContext(specCtx, GinkgoT())
 		defer controller.Finish()
 
-		mockEndorser := NewMockEndorserClient(controller)
-		mockEndorser.EXPECT().
-			ProcessProposal(gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(NewProposalResponse(expectedStatus, expectedMessage), nil)
+		mockConnection := NewMockClientConnInterface(controller)
+		mockConnection.EXPECT().
+			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
+			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
+				CopyProto(NewProposalResponse(expectedStatus, expectedMessage), out)
+			})
 
-		err := chaincode.Install(ctx, mockEndorser, mockSigner, packageReader)
+		err := chaincode.Install(ctx, mockConnection, mockSigner, packageReader)
 
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(And(
@@ -148,18 +157,18 @@ var _ = Describe("Install", func() {
 		defer controller.Finish()
 
 		var signedProposal *peer.SignedProposal
-		mockEndorser := NewMockEndorserClient(controller)
-		mockEndorser.EXPECT().
-			ProcessProposal(gomock.Any(), gomock.Any(), gomock.Any()).
-			Do(func(_ context.Context, in *peer.SignedProposal, _ ...grpc.CallOption) {
+		mockConnection := NewMockClientConnInterface(controller)
+		mockConnection.EXPECT().
+			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
+			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
 				signedProposal = in
+				CopyProto(NewProposalResponse(common.Status_SUCCESS, ""), out)
 			}).
-			Return(NewProposalResponse(common.Status_SUCCESS, ""), nil).
 			Times(1)
 
 		mockSigner.SignReturns(expected, nil)
 
-		err := chaincode.Install(ctx, mockEndorser, mockSigner, packageReader)
+		err := chaincode.Install(ctx, mockConnection, mockSigner, packageReader)
 		Expect(err).NotTo(HaveOccurred())
 
 		actual := signedProposal.GetSignature()
@@ -173,18 +182,18 @@ var _ = Describe("Install", func() {
 		defer controller.Finish()
 
 		var signedProposal *peer.SignedProposal
-		mockEndorser := NewMockEndorserClient(controller)
-		mockEndorser.EXPECT().
-			ProcessProposal(gomock.Any(), gomock.Any(), gomock.Any()).
-			Do(func(_ context.Context, in *peer.SignedProposal, _ ...grpc.CallOption) {
+		mockConnection := NewMockClientConnInterface(controller)
+		mockConnection.EXPECT().
+			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
+			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
 				signedProposal = in
+				CopyProto(NewProposalResponse(common.Status_SUCCESS, ""), out)
 			}).
-			Return(NewProposalResponse(common.Status_SUCCESS, ""), nil).
 			Times(1)
 
 		packageReader = bytes.NewReader(expected)
 
-		err := chaincode.Install(ctx, mockEndorser, mockSigner, packageReader)
+		err := chaincode.Install(ctx, mockConnection, mockSigner, packageReader)
 		Expect(err).NotTo(HaveOccurred())
 
 		invocationSpec := AssertUnmarshalInvocationSpec(signedProposal)
@@ -195,7 +204,7 @@ var _ = Describe("Install", func() {
 		AssertUnmarshal(args[1], chaincodeArgs)
 
 		actual := chaincodeArgs.GetChaincodeInstallPackage()
-		Expect(actual).To(BeEquivalentTo(expected), "chaincode pakcage")
+		Expect(actual).To(BeEquivalentTo(expected), "chaincode package")
 	})
 
 	It("Proposal includes creator", func(specCtx SpecContext) {
@@ -205,18 +214,18 @@ var _ = Describe("Install", func() {
 		defer controller.Finish()
 
 		var signedProposal *peer.SignedProposal
-		mockEndorser := NewMockEndorserClient(controller)
-		mockEndorser.EXPECT().
-			ProcessProposal(gomock.Any(), gomock.Any(), gomock.Any()).
-			Do(func(_ context.Context, in *peer.SignedProposal, _ ...grpc.CallOption) {
+		mockConnection := NewMockClientConnInterface(controller)
+		mockConnection.EXPECT().
+			Invoke(gomock.Any(), gomock.Eq(processProposalMethod), gomock.Any(), gomock.Any(), gomock.Any()).
+			Do(func(ctx context.Context, method string, in *peer.SignedProposal, out *peer.ProposalResponse, opts ...grpc.CallOption) {
 				signedProposal = in
+				CopyProto(NewProposalResponse(common.Status_SUCCESS, ""), out)
 			}).
-			Return(NewProposalResponse(common.Status_SUCCESS, ""), nil).
 			Times(1)
 
 		mockSigner.SerializeReturns(expected, nil)
 
-		err := chaincode.Install(ctx, mockEndorser, mockSigner, packageReader)
+		err := chaincode.Install(ctx, mockConnection, mockSigner, packageReader)
 		Expect(err).NotTo(HaveOccurred())
 
 		signatureHeader := AssertUnmarshalSignatureHeader(signedProposal)

--- a/go/pkg/chaincode/queryinstalled.go
+++ b/go/pkg/chaincode/queryinstalled.go
@@ -13,12 +13,14 @@ import (
 
 	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
 	"github.com/hyperledger/fabric-protos-go-apiv2/peer/lifecycle"
+	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 )
 
 const queryInstalledTransactionName = "QueryInstalledChaincodes"
 
-func QueryInstalled(ctx context.Context, endorser peer.EndorserClient, signer identity.SignerSerializer) (*lifecycle.QueryInstalledChaincodesResult, error) {
+// QueryInstalled chaincode on a specific peer.
+func QueryInstalled(ctx context.Context, connection grpc.ClientConnInterface, signer identity.SignerSerializer) (*lifecycle.QueryInstalledChaincodesResult, error) {
 	queryArgs := &lifecycle.QueryInstalledChaincodesArgs{}
 	queryArgsBytes, err := proto.Marshal(queryArgs)
 	if err != nil {
@@ -34,6 +36,8 @@ func QueryInstalled(ctx context.Context, endorser peer.EndorserClient, signer id
 	if err != nil {
 		return nil, err
 	}
+
+	endorser := peer.NewEndorserClient(connection)
 
 	proposalResponse, err := endorser.ProcessProposal(ctx, signedProposal)
 	if err != nil {

--- a/go/pkg/internal/proposal/builder.go
+++ b/go/pkg/internal/proposal/builder.go
@@ -46,6 +46,7 @@ func NewProposal(
 
 	builder := &builder{
 		chaincodeName:   chaincodeName,
+		headerType:      common.HeaderType_ENDORSER_TRANSACTION,
 		transactionName: transactionName,
 		transactionCtx:  transactionCtx,
 	}
@@ -62,6 +63,7 @@ func NewProposal(
 type builder struct {
 	channelName     string
 	chaincodeName   string
+	headerType      common.HeaderType
 	transactionName string
 	transactionCtx  *transactionContext
 	transient       map[string][]byte
@@ -180,6 +182,13 @@ func WithTransient(transient map[string][]byte) Option {
 func WithChannel(channelName string) Option {
 	return func(b *builder) error {
 		b.channelName = channelName
+		return nil
+	}
+}
+
+func WithType(headerType common.HeaderType) Option {
+	return func(b *builder) error {
+		b.headerType = headerType
 		return nil
 	}
 }


### PR DESCRIPTION
Previously the caller was required to create an EndorserClient, which is not something the client needs to know or care about. It is an implementation detail that should remain hidden within the SDK.

Also:

- Refactored some other code to use internal proposal package for building and signing proposals, rather than rely on Fabric protoutil.