### PR TITLE
New SigningIdentity abstraction

### DIFF
--- a/go/internal/protoutil/protoutil.go
+++ b/go/internal/protoutil/protoutil.go
@@ -3,7 +3,7 @@ package protoutil
 import (
 	"bytes"
 	"errors"
-	"fabric-admin-sdk/internal/pkg/identity"
+	"fabric-admin-sdk/pkg/identity"
 	"fmt"
 
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
@@ -16,7 +16,7 @@ import (
 // submit it to peers for ordering
 func CreateSignedTx(
 	proposal *peer.Proposal,
-	signer identity.CryptoImpl,
+	signer identity.Signer,
 	resps ...*peer.ProposalResponse,
 ) (*common.Envelope, error) {
 	if len(resps) == 0 {
@@ -33,22 +33,6 @@ func CreateSignedTx(
 	pPayl, err := UnmarshalChaincodeProposalPayload(proposal.Payload)
 	if err != nil {
 		return nil, err
-	}
-
-	// check that the signer is the same that is referenced in the header
-	// TODO: maybe worth removing?
-	signerBytes, err := signer.Serialize()
-	if err != nil {
-		return nil, err
-	}
-
-	shdr, err := UnmarshalSignatureHeader(hdr.SignatureHeader)
-	if err != nil {
-		return nil, err
-	}
-
-	if !bytes.Equal(signerBytes, shdr.Creator) {
-		return nil, errors.New("signer must be the same as the one referenced in the header")
 	}
 
 	// ensure that all actions are bitwise equal and that they are successful

--- a/go/pkg/chaincode/commit.go
+++ b/go/pkg/chaincode/commit.go
@@ -1,7 +1,7 @@
 package chaincode
 
 import (
-	"fabric-admin-sdk/internal/pkg/identity"
+	"fabric-admin-sdk/pkg/identity"
 	"fabric-admin-sdk/pkg/internal/proposal"
 
 	"github.com/hyperledger/fabric-protos-go-apiv2/orderer"
@@ -26,15 +26,15 @@ type CCDefine struct {
 	CollectionConfigPackage  *peer.CollectionConfigPackage
 }
 
-func Commit(CCDefine CCDefine, signer identity.CryptoImpl, EndorserClients []peer.EndorserClient, BroadcastClient orderer.AtomicBroadcast_BroadcastClient) error {
-	proposal, err := createCommitProposal(CCDefine, signer)
+func Commit(CCDefine CCDefine, id identity.SigningIdentity, EndorserClients []peer.EndorserClient, BroadcastClient orderer.AtomicBroadcast_BroadcastClient) error {
+	proposal, err := createCommitProposal(CCDefine, id)
 	if err != nil {
 		return err
 	}
-	return processProposalWithBroadcast(proposal, signer, EndorserClients, BroadcastClient)
+	return processProposalWithBroadcast(proposal, id, EndorserClients, BroadcastClient)
 }
 
-func createCommitProposal(CCDefine CCDefine, signer identity.CryptoImpl) (*peer.Proposal, error) {
+func createCommitProposal(CCDefine CCDefine, id identity.SigningIdentity) (*peer.Proposal, error) {
 	args := &lifecycle.CommitChaincodeDefinitionArgs{
 		Name:                CCDefine.Name,
 		Version:             CCDefine.Version,
@@ -51,5 +51,5 @@ func createCommitProposal(CCDefine CCDefine, signer identity.CryptoImpl) (*peer.
 		return nil, err
 	}
 
-	return proposal.NewProposal(signer, lifecycleName, commitFuncName, proposal.WithChannel(CCDefine.ChannelID), proposal.WithArguments(argsBytes))
+	return proposal.NewProposal(id, lifecycleChaincodeName, commitFuncName, proposal.WithChannel(CCDefine.ChannelID), proposal.WithArguments(argsBytes))
 }

--- a/go/pkg/chaincode/install.go
+++ b/go/pkg/chaincode/install.go
@@ -2,7 +2,7 @@ package chaincode
 
 import (
 	"context"
-	"fabric-admin-sdk/internal/pkg/identity"
+	"fabric-admin-sdk/pkg/identity"
 	"fabric-admin-sdk/pkg/internal/proposal"
 	"fmt"
 	"io"
@@ -13,13 +13,10 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-const (
-	lifecycleChaincodeName = "_lifecycle"
-	installTransactionName = "InstallChaincode"
-)
+const installTransactionName = "InstallChaincode"
 
 // Install a chaincode package to specific peer.
-func Install(ctx context.Context, connection grpc.ClientConnInterface, signer identity.SignerSerializer, packageReader io.Reader) error {
+func Install(ctx context.Context, connection grpc.ClientConnInterface, signingID identity.SigningIdentity, packageReader io.Reader) error {
 	packageBytes, err := io.ReadAll(packageReader)
 	if err != nil {
 		return fmt.Errorf("failed to read chaincode package: %w", err)
@@ -33,12 +30,12 @@ func Install(ctx context.Context, connection grpc.ClientConnInterface, signer id
 		return err
 	}
 
-	proposalProto, err := proposal.NewProposal(signer, lifecycleChaincodeName, installTransactionName, proposal.WithArguments(installArgsBytes))
+	proposalProto, err := proposal.NewProposal(signingID, lifecycleChaincodeName, installTransactionName, proposal.WithArguments(installArgsBytes))
 	if err != nil {
 		return err
 	}
 
-	signedProposal, err := proposal.NewSignedProposal(proposalProto, signer)
+	signedProposal, err := proposal.NewSignedProposal(proposalProto, signingID)
 	if err != nil {
 		return err
 	}

--- a/go/pkg/chaincode/lifecycle.go
+++ b/go/pkg/chaincode/lifecycle.go
@@ -1,0 +1,10 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package chaincode
+
+const (
+	lifecycleChaincodeName = "_lifecycle"
+)

--- a/go/pkg/chaincode/queryinstalled.go
+++ b/go/pkg/chaincode/queryinstalled.go
@@ -7,7 +7,7 @@ package chaincode
 
 import (
 	"context"
-	"fabric-admin-sdk/internal/pkg/identity"
+	"fabric-admin-sdk/pkg/identity"
 	"fabric-admin-sdk/pkg/internal/proposal"
 	"fmt"
 
@@ -20,19 +20,19 @@ import (
 const queryInstalledTransactionName = "QueryInstalledChaincodes"
 
 // QueryInstalled chaincode on a specific peer.
-func QueryInstalled(ctx context.Context, connection grpc.ClientConnInterface, signer identity.SignerSerializer) (*lifecycle.QueryInstalledChaincodesResult, error) {
+func QueryInstalled(ctx context.Context, connection grpc.ClientConnInterface, signingID identity.SigningIdentity) (*lifecycle.QueryInstalledChaincodesResult, error) {
 	queryArgs := &lifecycle.QueryInstalledChaincodesArgs{}
 	queryArgsBytes, err := proto.Marshal(queryArgs)
 	if err != nil {
 		return nil, err
 	}
 
-	proposalProto, err := proposal.NewProposal(signer, lifecycleChaincodeName, queryInstalledTransactionName, proposal.WithArguments(queryArgsBytes))
+	proposalProto, err := proposal.NewProposal(signingID, lifecycleChaincodeName, queryInstalledTransactionName, proposal.WithArguments(queryArgsBytes))
 	if err != nil {
 		return nil, err
 	}
 
-	signedProposal, err := proposal.NewSignedProposal(proposalProto, signer)
+	signedProposal, err := proposal.NewSignedProposal(proposalProto, signingID)
 	if err != nil {
 		return nil, err
 	}

--- a/go/pkg/channel/block.go
+++ b/go/pkg/channel/block.go
@@ -2,9 +2,8 @@ package channel
 
 import (
 	"context"
-	"fabric-admin-sdk/internal/pkg/identity"
+	"fabric-admin-sdk/pkg/identity"
 	"fabric-admin-sdk/pkg/internal/proposal"
-	"fabric-admin-sdk/pkg/tools"
 	"fmt"
 
 	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
@@ -13,13 +12,8 @@ import (
 )
 
 // GetConfigBlock get block config
-func GetConfigBlock(signCert, priKey, MSPID, channelID string, connection pb.EndorserClient) (*cb.Block, error) {
-
-	signer, err := tools.CreateSigner(priKey, signCert, MSPID)
-	if err != nil {
-		return nil, fmt.Errorf("create signer %w", err)
-	}
-	proposalResp, err := getSignedProposal(channelID, "cscc", "GetConfigBlock", signer, connection)
+func GetConfigBlock(id identity.SigningIdentity, channelID string, connection pb.EndorserClient) (*cb.Block, error) {
+	proposalResp, err := getSignedProposal(channelID, "cscc", "GetConfigBlock", id, connection)
 	if err != nil {
 		return nil, fmt.Errorf("get signed proposal %w", err)
 	}
@@ -32,13 +26,8 @@ func GetConfigBlock(signCert, priKey, MSPID, channelID string, connection pb.End
 }
 
 // GetBlockChainInfo get chain info
-func GetBlockChainInfo(signCert, priKey, MSPID, channelID string, connection pb.EndorserClient) (*cb.BlockchainInfo, error) {
-
-	signer, err := tools.CreateSigner(priKey, signCert, MSPID)
-	if err != nil {
-		return nil, fmt.Errorf("get signer %w", err)
-	}
-	proposalResp, err := getSignedProposal(channelID, "qscc", "GetChainInfo", signer, connection)
+func GetBlockChainInfo(id identity.SigningIdentity, channelID string, connection pb.EndorserClient) (*cb.BlockchainInfo, error) {
+	proposalResp, err := getSignedProposal(channelID, "qscc", "GetChainInfo", id, connection)
 	if err != nil {
 		return nil, fmt.Errorf("get signed proposal %w", err)
 	}
@@ -51,13 +40,13 @@ func GetBlockChainInfo(signCert, priKey, MSPID, channelID string, connection pb.
 	return blockChainInfo, nil
 }
 
-func getSignedProposal(channelID, ccName, funcName string, signer *identity.CryptoImpl, connection pb.EndorserClient) (*pb.ProposalResponse, error) {
-	prop, err := proposal.NewProposal(signer, ccName, funcName, proposal.WithChannel(channelID), proposal.WithArguments([]byte(channelID)))
+func getSignedProposal(channelID, ccName, funcName string, id identity.SigningIdentity, connection pb.EndorserClient) (*pb.ProposalResponse, error) {
+	prop, err := proposal.NewProposal(id, ccName, funcName, proposal.WithChannel(channelID), proposal.WithArguments([]byte(channelID)))
 	if err != nil {
 		return nil, err
 	}
 
-	signedProp, err := proposal.NewSignedProposal(prop, signer)
+	signedProp, err := proposal.NewSignedProposal(prop, id)
 	if err != nil {
 		return nil, err
 	}

--- a/go/pkg/channel/channel.go
+++ b/go/pkg/channel/channel.go
@@ -6,8 +6,8 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fabric-admin-sdk/internal/osnadmin"
-	"fabric-admin-sdk/internal/pkg/identity"
 	"fabric-admin-sdk/internal/protoutil"
+	"fabric-admin-sdk/pkg/identity"
 	"fabric-admin-sdk/pkg/internal/proposal"
 	"fmt"
 	"io"
@@ -31,18 +31,18 @@ func CreateChannel(osnURL string, block *cb.Block, caCertPool *x509.CertPool, tl
 	return osnadmin.Join(osnURL, block_byte, caCertPool, tlsClientCert)
 }
 
-func JoinChannel(block *cb.Block, signer identity.CryptoImpl, connection pb.EndorserClient) error {
+func JoinChannel(block *cb.Block, id identity.SigningIdentity, connection pb.EndorserClient) error {
 	blockBytes, err := proto.Marshal(block)
 	if err != nil {
 		return fmt.Errorf("failed to marshal block: %w", err)
 	}
 
-	prop, err := proposal.NewProposal(signer, "cscc", "JoinChain", proposal.WithArguments(blockBytes), proposal.WithType(cb.HeaderType_CONFIG))
+	prop, err := proposal.NewProposal(id, "cscc", "JoinChain", proposal.WithArguments(blockBytes), proposal.WithType(cb.HeaderType_CONFIG))
 	if err != nil {
 		return err
 	}
 
-	signedProp, err := proposal.NewSignedProposal(prop, signer)
+	signedProp, err := proposal.NewSignedProposal(prop, id)
 	if err != nil {
 		return err
 	}

--- a/go/pkg/identity/credentials_test.go
+++ b/go/pkg/identity/credentials_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package identity_test
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"math/big"
+	"time"
+)
+
+// NewECDSAPrivateKey generates a new private key for testing
+func NewECDSAPrivateKey() (*ecdsa.PrivateKey, error) {
+	return ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+}
+
+func publicKey(priv crypto.PrivateKey) crypto.PublicKey {
+	switch k := priv.(type) {
+	case *rsa.PrivateKey:
+		return &k.PublicKey
+	case *ecdsa.PrivateKey:
+		return &k.PublicKey
+	case ed25519.PrivateKey:
+		return k.Public().(ed25519.PublicKey)
+	default:
+		return nil
+	}
+}
+
+// NewCertificate generates a new certificate from a private key for testing
+func NewCertificate(privateKey crypto.PrivateKey) (*x509.Certificate, error) {
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate serial number: %w", err)
+	}
+
+	notBefore := time.Now()
+	notAfter := notBefore.Add(time.Hour * 24)
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Test"},
+		},
+		NotBefore: notBefore,
+		NotAfter:  notAfter,
+
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+
+		DNSNames: []string{"test.example.org"},
+	}
+
+	certificateBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, publicKey(privateKey), privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate certificate: %w", err)
+	}
+
+	return x509.ParseCertificate(certificateBytes)
+}

--- a/go/pkg/identity/ecdsa.go
+++ b/go/pkg/identity/ecdsa.go
@@ -1,0 +1,51 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package identity
+
+import (
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/asn1"
+	"math/big"
+)
+
+func ecdsaPrivateKeySign(privateKey *ecdsa.PrivateKey) signFn {
+	n := privateKey.Params().Params().N
+
+	return func(message []byte) ([]byte, error) {
+		digest := sha256.Sum256(message)
+		r, s, err := ecdsa.Sign(rand.Reader, privateKey, digest[:])
+		if err != nil {
+			return nil, err
+		}
+
+		s = canonicalECDSASignatureSValue(s, n)
+
+		return asn1ECDSASignature(r, s)
+	}
+}
+
+func canonicalECDSASignatureSValue(s *big.Int, curveN *big.Int) *big.Int {
+	halfOrder := new(big.Int).Rsh(curveN, 1)
+	if s.Cmp(halfOrder) <= 0 {
+		return s
+	}
+
+	// Set s to N - s so it is in the lower part of signature space, less or equal to half order
+	return new(big.Int).Sub(curveN, s)
+}
+
+type ecdsaSignature struct {
+	R, S *big.Int
+}
+
+func asn1ECDSASignature(r, s *big.Int) ([]byte, error) {
+	return asn1.Marshal(ecdsaSignature{
+		R: r,
+		S: s,
+	})
+}

--- a/go/pkg/identity/identity.go
+++ b/go/pkg/identity/identity.go
@@ -1,0 +1,78 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package identity
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/x509"
+	"fmt"
+)
+
+// Identity used to interact with a Fabric network.
+type Identity interface {
+	MspID() string       // ID of the Membership Service Provider to which this identity belongs.
+	Credentials() []byte // Implementation-specific credentials.
+}
+
+// Signer can sign messages using an identity's private credentials.
+type Signer interface {
+	Sign(message []byte) ([]byte, error)
+}
+
+// SigningIdentity represents an identity that is able to sign messages.
+type SigningIdentity interface {
+	Identity
+	Signer
+}
+
+func NewPrivateKeySigningIdentity(mspID string, certificate *x509.Certificate, privateKey crypto.PrivateKey) (SigningIdentity, error) {
+	credentials, err := certificateToPEM(certificate)
+	if err != nil {
+		return nil, err
+	}
+
+	sign, err := newPrivateKeySign(privateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	id := &signingIdentity{
+		mspID:       mspID,
+		credentials: credentials,
+		sign:        sign,
+	}
+	return id, nil
+}
+
+type signFn func([]byte) ([]byte, error)
+
+func newPrivateKeySign(privateKey crypto.PrivateKey) (signFn, error) {
+	switch key := privateKey.(type) {
+	case *ecdsa.PrivateKey:
+		return ecdsaPrivateKeySign(key), nil
+	default:
+		return nil, fmt.Errorf("unsupported key type: %T", privateKey)
+	}
+}
+
+type signingIdentity struct {
+	mspID       string
+	credentials []byte
+	sign        signFn
+}
+
+func (id *signingIdentity) MspID() string {
+	return id.mspID
+}
+
+func (id *signingIdentity) Credentials() []byte {
+	return id.credentials
+}
+
+func (id *signingIdentity) Sign(message []byte) ([]byte, error) {
+	return id.sign(message)
+}

--- a/go/pkg/identity/identity_suite_test.go
+++ b/go/pkg/identity/identity_suite_test.go
@@ -1,0 +1,18 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package identity_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestIdentity(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Identity Suite")
+}

--- a/go/pkg/identity/identity_test.go
+++ b/go/pkg/identity/identity_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package identity_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/pem"
+	"fabric-admin-sdk/pkg/identity"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func DecodeCertificatePEM(certificatePEM []byte) *x509.Certificate {
+	block, _ := pem.Decode(certificatePEM)
+	certificate, err := x509.ParseCertificate(block.Bytes)
+	Expect(err).NotTo(HaveOccurred())
+
+	return certificate
+}
+
+var _ = Describe("SigningIdentity", func() {
+	var certificate *x509.Certificate
+	var privateKey *ecdsa.PrivateKey
+
+	BeforeEach(func() {
+		var err error
+
+		privateKey, err = NewECDSAPrivateKey()
+		Expect(err).NotTo(HaveOccurred())
+
+		certificate, err = NewCertificate(privateKey)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("Has MSP ID", func(specCtx SpecContext) {
+		id, err := identity.NewPrivateKeySigningIdentity("MSP_ID", certificate, privateKey)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(id.MspID()).To(Equal("MSP_ID"))
+	})
+
+	It("Has certificate", func(specCtx SpecContext) {
+		id, err := identity.NewPrivateKeySigningIdentity("MSP_ID", certificate, privateKey)
+		Expect(err).NotTo(HaveOccurred())
+
+		actual := DecodeCertificatePEM(id.Credentials())
+		Expect(actual).To(Equal(certificate))
+	})
+
+	It("Creates valid signature", func(specCtx SpecContext) {
+		id, err := identity.NewPrivateKeySigningIdentity("", certificate, privateKey)
+		Expect(err).NotTo(HaveOccurred())
+
+		message := []byte("MESSAGE")
+
+		signature, err := id.Sign(message)
+		Expect(err).NotTo(HaveOccurred())
+
+		hash := sha256.Sum256(message)
+
+		valid := ecdsa.VerifyASN1(&privateKey.PublicKey, hash[:], signature)
+		Expect(valid).To(BeTrue())
+	})
+})

--- a/go/pkg/identity/pem.go
+++ b/go/pkg/identity/pem.go
@@ -1,0 +1,29 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package identity
+
+import (
+	"bytes"
+	"crypto/x509"
+	"encoding/pem"
+)
+
+func certificateToPEM(certificate *x509.Certificate) ([]byte, error) {
+	block := &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certificate.Raw,
+	}
+	return pemEncode(block)
+}
+
+func pemEncode(block *pem.Block) ([]byte, error) {
+	var buffer bytes.Buffer
+	if err := pem.Encode(&buffer, block); err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), nil
+}

--- a/go/pkg/internal/proposal/builder.go
+++ b/go/pkg/internal/proposal/builder.go
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 package proposal
 
 import (
-	"fabric-admin-sdk/internal/pkg/identity"
+	"fabric-admin-sdk/pkg/identity"
 	"fmt"
 
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
@@ -34,12 +34,12 @@ func NewSignedProposal(proposal *peer.Proposal, signer identity.Signer) (*peer.S
 }
 
 func NewProposal(
-	serializer identity.Serializer,
+	id identity.Identity,
 	chaincodeName string,
 	transactionName string,
 	options ...Option,
 ) (*peer.Proposal, error) {
-	transactionCtx, err := newTransactionContext(serializer)
+	transactionCtx, err := newTransactionContext(id)
 	if err != nil {
 		return nil, err
 	}

--- a/go/pkg/internal/proposal/transactioncontext.go
+++ b/go/pkg/internal/proposal/transactioncontext.go
@@ -9,9 +9,11 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
-	"fabric-admin-sdk/internal/pkg/identity"
+	"fabric-admin-sdk/pkg/identity"
 
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/hyperledger/fabric-protos-go-apiv2/msp"
+	"google.golang.org/protobuf/proto"
 )
 
 type transactionContext struct {
@@ -19,13 +21,17 @@ type transactionContext struct {
 	SignatureHeader *common.SignatureHeader
 }
 
-func newTransactionContext(serializer identity.Serializer) (*transactionContext, error) {
+func newTransactionContext(id identity.Identity) (*transactionContext, error) {
 	nonce := make([]byte, 24)
 	if _, err := rand.Read(nonce); err != nil {
 		return nil, err
 	}
 
-	creator, err := serializer.Serialize()
+	serializedIdentity := &msp.SerializedIdentity{
+		Mspid:   id.MspID(),
+		IdBytes: id.Credentials(),
+	}
+	creator, err := proto.Marshal(serializedIdentity)
 	if err != nil {
 		return nil, err
 	}

--- a/go/test/channel_test.go
+++ b/go/test/channel_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"fabric-admin-sdk/internal/network"
 	"fabric-admin-sdk/pkg/channel"
+	"fabric-admin-sdk/pkg/tools"
 	"fmt"
 	"os"
 
@@ -62,8 +63,11 @@ var _ = Describe("channel", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			connection := npb.NewEndorserClient(n_conn1)
+
+			id, err := tools.CreateSigner(PrivKeyPath, SignCert, MSPID)
 			Expect(err).NotTo(HaveOccurred())
-			configBlock, err := channel.GetConfigBlock(SignCert, PrivKeyPath, MSPID, channelID, connection)
+
+			configBlock, err := channel.GetConfigBlock(id, channelID, connection)
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println("config block", configBlock)
 		})
@@ -91,7 +95,11 @@ var _ = Describe("channel", func() {
 			n_conn1, err := network.DialConnection(peer1)
 			Expect(err).NotTo(HaveOccurred())
 			connection := npb.NewEndorserClient(n_conn1)
-			blockChainInfo, err := channel.GetBlockChainInfo(SignCert, PrivKeyPath, MSPID, channelID, connection)
+
+			id, err := tools.CreateSigner(PrivKeyPath, SignCert, MSPID)
+			Expect(err).NotTo(HaveOccurred())
+
+			blockChainInfo, err := channel.GetBlockChainInfo(id, channelID, connection)
 			Expect(err).NotTo(HaveOccurred())
 			fmt.Println("blockchain info", blockChainInfo)
 		})


### PR DESCRIPTION
Provides a more abstract view of client identity consisting of only:

- MSP ID
- credentials (typically X.509 certificate PEM)
- signing implementation (typically based on a private key)

This avoids an identity implementor from requiring knowledge of the SerializedIdentity format used internally by Fabric. It also aligns better with the abstraction used by the Fabric Gateway client API, allowing the admin SDK implementation to make use of fabric-gateway.