### PR TITLE
public apis for end-to-end tests

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,5 +1,13 @@
 package util
 
+import (
+	"errors"
+
+	"github.com/hyperledger/fabric-admin-sdk/internal/protoutil"
+	"github.com/hyperledger/fabric-admin-sdk/pkg/identity"
+	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
+)
+
 func Concatenate[T any](slices ...[]T) []T {
 	size := 0
 	for _, slice := range slices {
@@ -14,4 +22,56 @@ func Concatenate[T any](slices ...[]T) []T {
 	}
 
 	return result
+}
+
+const (
+	msgVersion = int32(0)
+	epoch      = 0
+)
+
+func SignConfigTx(channelID string, envConfigUpdate *cb.Envelope, signer identity.SigningIdentity) (*cb.Envelope, error) {
+	payload, err := protoutil.UnmarshalPayload(envConfigUpdate.GetPayload())
+	if err != nil {
+		return nil, errors.New("bad payload")
+	}
+
+	if payload.GetHeader() == nil || payload.Header.ChannelHeader == nil {
+		return nil, errors.New("bad header")
+	}
+
+	ch, err := protoutil.UnmarshalChannelHeader(payload.GetHeader().GetChannelHeader())
+	if err != nil {
+		return nil, errors.New("could not unmarshall channel header")
+	}
+
+	if ch.GetType() != int32(cb.HeaderType_CONFIG_UPDATE) {
+		return nil, errors.New("bad type")
+	}
+
+	if ch.GetChannelId() == "" {
+		return nil, errors.New("empty channel id")
+	}
+
+	configUpdateEnv, err := protoutil.UnmarshalConfigUpdateEnvelope(payload.GetData())
+	if err != nil {
+		return nil, errors.New("bad config update env")
+	}
+
+	sigHeader, err := protoutil.NewSignatureHeader(signer)
+	if err != nil {
+		return nil, err
+	}
+
+	configSig := &cb.ConfigSignature{
+		SignatureHeader: protoutil.MarshalOrPanic(sigHeader),
+	}
+
+	configSig.Signature, err = signer.Sign(Concatenate(configSig.GetSignatureHeader(), configUpdateEnv.GetConfigUpdate()))
+	if err != nil {
+		return nil, err
+	}
+
+	configUpdateEnv.Signatures = append(configUpdateEnv.Signatures, configSig)
+
+	return protoutil.CreateSignedEnvelope(cb.HeaderType_CONFIG_UPDATE, channelID, signer, configUpdateEnv, msgVersion, epoch)
 }

--- a/test/e2e_suite_test.go
+++ b/test/e2e_suite_test.go
@@ -1,23 +1,11 @@
 package test
 
 import (
-	"errors"
 	"os"
 	"testing"
 
-	"github.com/hyperledger/fabric-admin-sdk/internal/configtxgen/encoder"
-	"github.com/hyperledger/fabric-admin-sdk/internal/configtxgen/genesisconfig"
-	"github.com/hyperledger/fabric-admin-sdk/internal/protoutil"
-	"github.com/hyperledger/fabric-admin-sdk/internal/util"
-	"github.com/hyperledger/fabric-admin-sdk/pkg/identity"
-	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-)
-
-const (
-	msgVersion = int32(0)
-	epoch      = 0
 )
 
 func TestE2e(t *testing.T) {
@@ -34,60 +22,3 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	_ = os.RemoveAll(tmpDir)
 })
-
-// ConfigTxGen based on Profile return block
-func ConfigTxGen(config *genesisconfig.Profile, channelID string) (*cb.Block, error) {
-	pgen, err := encoder.NewBootstrapper(config)
-	if err != nil {
-		return nil, err
-	}
-	genesisBlock := pgen.GenesisBlockForChannel(channelID)
-	return genesisBlock, nil
-}
-
-func SignConfigTx(channelID string, envConfigUpdate *cb.Envelope, signer identity.SigningIdentity) (*cb.Envelope, error) {
-	payload, err := protoutil.UnmarshalPayload(envConfigUpdate.GetPayload())
-	if err != nil {
-		return nil, errors.New("bad payload")
-	}
-
-	if payload.GetHeader() == nil || payload.Header.ChannelHeader == nil {
-		return nil, errors.New("bad header")
-	}
-
-	ch, err := protoutil.UnmarshalChannelHeader(payload.GetHeader().GetChannelHeader())
-	if err != nil {
-		return nil, errors.New("could not unmarshall channel header")
-	}
-
-	if ch.GetType() != int32(cb.HeaderType_CONFIG_UPDATE) {
-		return nil, errors.New("bad type")
-	}
-
-	if ch.GetChannelId() == "" {
-		return nil, errors.New("empty channel id")
-	}
-
-	configUpdateEnv, err := protoutil.UnmarshalConfigUpdateEnvelope(payload.GetData())
-	if err != nil {
-		return nil, errors.New("bad config update env")
-	}
-
-	sigHeader, err := protoutil.NewSignatureHeader(signer)
-	if err != nil {
-		return nil, err
-	}
-
-	configSig := &cb.ConfigSignature{
-		SignatureHeader: protoutil.MarshalOrPanic(sigHeader),
-	}
-
-	configSig.Signature, err = signer.Sign(util.Concatenate(configSig.GetSignatureHeader(), configUpdateEnv.GetConfigUpdate()))
-	if err != nil {
-		return nil, err
-	}
-
-	configUpdateEnv.Signatures = append(configUpdateEnv.Signatures, configSig)
-
-	return protoutil.CreateSignedEnvelope(cb.HeaderType_CONFIG_UPDATE, channelID, signer, configUpdateEnv, msgVersion, epoch)
-}


### PR DESCRIPTION
This PR aims to address [issue 207 ](https://github.com/hyperledger/fabric-admin-sdk/issues/207) by introducing two new functions on the channel api (UpdateChannelConfig and CreateGenesisBlock) that allow the tests in test/e2e_test.go and test/channel_test.go to be written without calls to internal functions.  These two test codes are rewritten to use these functions; a little bit of the ensuing reorganization affects other files (e.g. the SignConfigTx function has been moved from test/e2e_suite_test.go to internal/util/util.go).  