### PR TITLE
Use reflect.Pointer instead of reflect.Ptr

### DIFF
--- a/internal/configtxgen/viperutil/config_util.go
+++ b/internal/configtxgen/viperutil/config_util.go
@@ -454,7 +454,7 @@ func bccspHook(f reflect.Type, t reflect.Type, data interface{}) (interface{}, e
 // the time.Duration type
 func (c *ConfigParser) EnhancedExactUnmarshal(output interface{}) error {
 	oType := reflect.TypeOf(output)
-	if oType.Kind() != reflect.Ptr {
+	if oType.Kind() != reflect.Pointer {
 		return errors.New("supplied output argument must be a pointer to a struct but is not pointer")
 	}
 	eType := oType.Elem()


### PR DESCRIPTION
reflect.Pointer replaced reflect.Ptr in Go 1.18. For backwards compatibility, reflect.Ptr is a constant with the value of reflect.Pointer. The use of this constant triggers a lint failure as it should be inlined. This can be avoided by using the preferred reflect.Pointer constant.